### PR TITLE
[MODTEMPENG-13] Make header and body of template required

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "provides": [
     {
       "id": "template-engine",
-      "version": "1.1",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/template-engine.raml
+++ b/ramls/template-engine.raml
@@ -2,7 +2,7 @@
 
 title: Template engine
 baseUri: http://api.example.com/{version}
-version: v1.1
+version: v2.0
 
 
 documentation:

--- a/ramls/templateContent.json
+++ b/ramls/templateContent.json
@@ -6,11 +6,17 @@
   "properties": {
     "header": {
       "type": "string",
+      "pattern": "\\S+.*",
       "description": "Template for header"
     },
     "body": {
       "type": "string",
+      "pattern": "\\S+.*",
       "description": "Template for body"
     }
-  }
+  },
+  "required": [
+    "header",
+    "body"
+  ]
 }


### PR DESCRIPTION
## Purpose
Resolves: MODTEMPENG-13
Make header and body of template required
Has to be merged together with: 
https://github.com/folio-org/mod-notify/pull/70
https://github.com/folio-org/ui-circulation/pull/306
## Links
https://issues.folio.org/browse/MODTEMPENG-13
https://github.com/folio-org/mod-notify/pull/70
https://github.com/folio-org/ui-circulation/pull/306