### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-template-engine
 
-Copyright (C) 2018 The Open Library Foundation
+Copyright (C) 2018-2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,8 @@ Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/
 See project [MODTEMPENG](https://issues.folio.org/browse/MODTEMPENG)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
+### ModuleDescriptor
+
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -99,6 +99,10 @@
       "visible": false
     }
   ],
+  "metadata": {
+    "containerMemory": "256",
+    "databaseConnection": "true"
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)