### PR TITLE
MODTEMPENG-18 Localize dates from context at the time of template processing

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,7 +1,12 @@
 {
   "id": "${artifactId}-${version}",
   "name": "Template engine module",
-  "requires": [],
+  "requires": [
+    {
+      "id": "configuration",
+      "version": "2.0"
+    }
+  ],
   "provides": [
     {
       "id": "template-engine",
@@ -35,7 +40,10 @@
         {
           "methods": ["POST"],
           "pathPattern": "/template-request",
-          "permissionsRequired": ["template-request.post"]
+          "permissionsRequired": ["template-request.post"],
+          "modulePermissions": [
+            "configuration.entries.collection.get"
+          ]
         }
       ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx-version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
       <artifactId>compiler</artifactId>
       <version>0.9.5</version>
@@ -60,9 +65,9 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>2.9.0</version>
+      <version>3.2.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -127,6 +132,18 @@
       <version>1.0.4</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>2.23.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.jopt-simple</groupId>
+          <artifactId>jopt-simple</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/ramls/configuration.json
+++ b/ramls/configuration.json
@@ -4,31 +4,40 @@
   "properties": {
     "id": {
       "type": "string",
+      "description": "Configuration id",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
     "module": {
-      "type": "string"
+      "type": "string",
+      "description": "Module name"
     },
     "configName": {
-      "type": "string"
+      "type": "string",
+      "description": "Config name"
     },
     "code": {
-      "type": "string"
+      "type": "string",
+      "description": "Configuration code"
     },
     "description": {
-      "type": "string"
+      "type": "string",
+      "description": "Configuration record description"
     },
     "default": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Value is default"
     },
     "enabled": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Configuration is enabled"
     },
     "value": {
-      "type": "string"
+      "type": "string",
+      "description": "Configuration value"
     },
     "userId": {
-      "type": "string"
+      "type": "string",
+      "description": "User id"
     },
     "metadata": {
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/configuration.json
+++ b/ramls/configuration.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "module": {
+      "type": "string"
+    },
+    "configName": {
+      "type": "string"
+    },
+    "code": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": {
+      "type": "boolean"
+    },
+    "enabled": {
+      "type": "boolean"
+    },
+    "value": {
+      "type": "string"
+    },
+    "userId": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "module",
+    "configName"
+  ]
+}

--- a/ramls/configuration.json
+++ b/ramls/configuration.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "description": "Configuration",
   "properties": {
     "id": {
       "type": "string",

--- a/ramls/configurations.json
+++ b/ramls/configurations.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "configs": {
+      "id": "configurationData",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "configuration.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    },
+    "resultInfo": {
+      "$ref": "raml-util/schemas/resultInfo.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "configs",
+    "totalRecords"
+  ]
+}

--- a/ramls/configurations.json
+++ b/ramls/configurations.json
@@ -4,6 +4,7 @@
   "properties": {
     "configs": {
       "id": "configurationData",
+      "description": "Array of configuration records",
       "type": "array",
       "items": {
         "type": "object",
@@ -11,7 +12,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Total number of records"
     },
     "resultInfo": {
       "$ref": "raml-util/schemas/resultInfo.schema",

--- a/ramls/configurations.json
+++ b/ramls/configurations.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "description": "Collection of configuration records",
   "properties": {
     "configs": {
       "id": "configurationData",

--- a/ramls/template-engine.raml
+++ b/ramls/template-engine.raml
@@ -15,6 +15,8 @@ types:
   templateProcessingRequest: !include templateProcessingRequest.json
   templateProcessingResult: !include templateProcessingResult.json
   errors: !include raml-util/schemas/errors.schema
+  configuration: !include configuration.json
+  configurations: !include configurations.json
 
 traits:
   pageable: !include ./raml-util/traits/pageable.raml

--- a/src/main/java/org/folio/rest/impl/TemplateRequestImpl.java
+++ b/src/main/java/org/folio/rest/impl/TemplateRequestImpl.java
@@ -4,25 +4,17 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import org.folio.rest.jaxrs.model.TemplateProcessingRequest;
 import org.folio.rest.jaxrs.resource.TemplateRequest;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.template.service.TemplateService;
 import org.folio.template.service.TemplateServiceImpl;
+import org.folio.template.util.OkapiConnectionParams;
 import org.folio.template.util.TemplateEngineHelper;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
 public class TemplateRequestImpl implements TemplateRequest {
-
-  private TemplateService templateService;
-
-  public TemplateRequestImpl(Vertx vertx, String tenantId) {
-    String calculatedTenantId = TenantTool.calculateTenantId(tenantId);
-    templateService = new TemplateServiceImpl(vertx, calculatedTenantId);
-  }
 
   @Override
   public void postTemplateRequest(TemplateProcessingRequest entity,
@@ -31,7 +23,8 @@ public class TemplateRequestImpl implements TemplateRequest {
                                   Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        templateService.processTemplate(entity)
+        TemplateService templateService = new TemplateServiceImpl(vertxContext.owner(), new OkapiConnectionParams(okapiHeaders));
+        templateService.processTemplate(entity, new OkapiConnectionParams(okapiHeaders))
           .map(PostTemplateRequestResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)

--- a/src/main/java/org/folio/rest/impl/TemplateResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/TemplateResourceImpl.java
@@ -4,14 +4,13 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.Template;
 import org.folio.rest.jaxrs.model.TemplatesCollection;
 import org.folio.rest.jaxrs.resource.Templates;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.template.service.TemplateService;
 import org.folio.template.service.TemplateServiceImpl;
+import org.folio.template.util.OkapiConnectionParams;
 import org.folio.template.util.TemplateEngineHelper;
 
 import javax.validation.constraints.NotNull;
@@ -22,18 +21,13 @@ import java.util.Map;
 
 public class TemplateResourceImpl implements Templates {
 
-  private TemplateService templateService;
-
-  public TemplateResourceImpl(Vertx vertx, String tenantId) {
-    String calculatedTenantId = TenantTool.calculateTenantId(tenantId);
-    this.templateService = new TemplateServiceImpl(vertx, calculatedTenantId);
-  }
 
   @Override
   public void postTemplates(Template entity, Map<String, String> okapiHeaders,
                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
+        TemplateService templateService = new TemplateServiceImpl(vertxContext.owner(), new OkapiConnectionParams(okapiHeaders));
         templateService.addTemplate(entity)
           .map((Response) PostTemplatesResponse.respond201WithApplicationJson(entity))
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)
@@ -52,6 +46,7 @@ public class TemplateResourceImpl implements Templates {
                            Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
+        TemplateService templateService = new TemplateServiceImpl(vertxContext.owner(), new OkapiConnectionParams(okapiHeaders));
         templateService.getTemplates(query, offset, limit)
           .map(templates -> new TemplatesCollection()
             .withTemplates(templates)
@@ -72,6 +67,7 @@ public class TemplateResourceImpl implements Templates {
                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
+        TemplateService templateService = new TemplateServiceImpl(vertxContext.owner(), new OkapiConnectionParams(okapiHeaders));
         templateService.getTemplateById(templateId)
           .map(optionalTemplate -> optionalTemplate.orElseThrow(() ->
             new NotFoundException(String.format("Template with id '%s' not found", templateId))))
@@ -93,6 +89,7 @@ public class TemplateResourceImpl implements Templates {
                                        Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
+        TemplateService templateService = new TemplateServiceImpl(vertxContext.owner(), new OkapiConnectionParams(okapiHeaders));
         entity.setId(templateId);
         templateService.updateTemplate(entity)
           .map(updated -> updated ?
@@ -115,6 +112,7 @@ public class TemplateResourceImpl implements Templates {
                                           Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
+        TemplateService templateService = new TemplateServiceImpl(vertxContext.owner(), new OkapiConnectionParams(okapiHeaders));
         templateService.deleteTemplate(templateId).map(deleted -> deleted ?
           DeleteTemplatesByTemplateIdResponse.respond204WithTextPlain(
             String.format("Template with id: %s deleted", templateId)) :

--- a/src/main/java/org/folio/template/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/template/client/ConfigurationClient.java
@@ -1,0 +1,11 @@
+package org.folio.template.client;
+
+
+import io.vertx.core.Future;
+import org.folio.template.util.OkapiConnectionParams;
+
+
+public interface ConfigurationClient {
+
+  Future<LocaleConfiguration> lookupLocaleConfig(OkapiConnectionParams okapiConnectionParams);
+}

--- a/src/main/java/org/folio/template/client/ConfigurationClientImpl.java
+++ b/src/main/java/org/folio/template/client/ConfigurationClientImpl.java
@@ -1,0 +1,84 @@
+package org.folio.template.client;
+
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import org.folio.HttpStatus;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configurations;
+import org.folio.template.util.OkapiConnectionParams;
+import org.folio.template.util.OkapiModuleClientException;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class ConfigurationClientImpl implements ConfigurationClient {
+
+  private static final String DEFAULT_LANGUAGE_TAG = "en-US";
+  private static final String DEFAULT_TIMEZONE_ID = "UTC";
+
+  private WebClient webClient;
+  private String configRequestPath;
+
+  public ConfigurationClientImpl(Vertx vertx) {
+    this.webClient = WebClient.create(vertx);
+    this.configRequestPath = System.getProperty("config.client.path", "/configurations/entries");
+  }
+
+  @Override
+  public Future<LocaleConfiguration> lookupLocaleConfig(OkapiConnectionParams okapiConnectionParams) {
+    return lookupConfigByModuleAndConfigName("ORG", "localeSettings", 0, 1, okapiConnectionParams)
+      .map(this::mapToLocaleConfiguration);
+  }
+
+  private Future<Configurations> lookupConfigByModuleAndConfigName(String moduleName, String configName,
+                                                                   int offset, int limit, OkapiConnectionParams params) {
+    String query = String.format("module=%s and configName=%s", moduleName, configName);
+    return lookupConfigByQuery(query, offset, limit, params);
+  }
+
+  private Future<Configurations> lookupConfigByQuery(String query, int offset, int limit, OkapiConnectionParams params) {
+
+    Future<HttpResponse<Buffer>> future = Future.future();
+    String requestUrl = params.getOkapiUrl() + configRequestPath;
+    webClient.getAbs(requestUrl)
+      .addQueryParam("query", query)
+      .addQueryParam("offset", Integer.toString(offset))
+      .addQueryParam("limit", Integer.toString(limit))
+      .putHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+      .putHeader(RestVerticle.OKAPI_HEADER_TENANT, params.getTenant())
+      .putHeader(RestVerticle.OKAPI_HEADER_TOKEN, params.getToken())
+      .send(future.completer());
+
+    return future.map(response -> {
+      if (response.statusCode() != HttpStatus.HTTP_OK.toInt()) {
+        String logMessage =
+          String.format("Error getting config by module name. Status: %d, body: %s", response.statusCode(), response.body());
+        throw new OkapiModuleClientException(logMessage);
+      }
+      return response.bodyAsJsonObject().mapTo(Configurations.class);
+    });
+  }
+
+  private LocaleConfiguration mapToLocaleConfiguration(Configurations configurations) {
+    JsonObject localeConfig = Optional.ofNullable(configurations.getConfigs())
+      .map(Collection::stream)
+      .orElse(Stream.empty())
+      .findFirst()
+      .map(Config::getValue)
+      .map(JsonObject::new)
+      .orElse(new JsonObject());
+
+    String languageTag = localeConfig.getString("locale", DEFAULT_LANGUAGE_TAG);
+    String timezoneId = localeConfig.getString("timezone", DEFAULT_TIMEZONE_ID);
+    return new LocaleConfiguration(languageTag, timezoneId);
+  }
+}

--- a/src/main/java/org/folio/template/client/LocaleConfiguration.java
+++ b/src/main/java/org/folio/template/client/LocaleConfiguration.java
@@ -1,0 +1,20 @@
+package org.folio.template.client;
+
+public class LocaleConfiguration {
+
+  private final String languageTag;
+  private final String timeZoneId;
+
+  public LocaleConfiguration(String languageTag, String timeZoneId) {
+    this.languageTag = languageTag;
+    this.timeZoneId = timeZoneId;
+  }
+
+  public String getLanguageTag() {
+    return languageTag;
+  }
+
+  public String getTimeZoneId() {
+    return timeZoneId;
+  }
+}

--- a/src/main/java/org/folio/template/service/TemplateService.java
+++ b/src/main/java/org/folio/template/service/TemplateService.java
@@ -4,7 +4,9 @@ import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.Template;
 import org.folio.rest.jaxrs.model.TemplateProcessingRequest;
 import org.folio.rest.jaxrs.model.TemplateProcessingResult;
+import org.folio.template.util.OkapiConnectionParams;
 
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Optional;
 
@@ -59,7 +61,9 @@ public interface TemplateService {
    * Gets template specified by id and process it with given context
    *
    * @param templateRequest template processing request
+   * @param okapiConnectionParams okapi connection params
    * @return template processing response
    */
-  Future<TemplateProcessingResult> processTemplate(TemplateProcessingRequest templateRequest);
+  Future<TemplateProcessingResult> processTemplate(
+    TemplateProcessingRequest templateRequest, OkapiConnectionParams okapiConnectionParams) throws UnsupportedEncodingException;
 }

--- a/src/main/java/org/folio/template/util/ContextDateTimeFormatter.java
+++ b/src/main/java/org/folio/template/util/ContextDateTimeFormatter.java
@@ -1,0 +1,63 @@
+package org.folio.template.util;
+
+import io.vertx.core.json.JsonObject;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.FormatStyle;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ContextDateTimeFormatter {
+
+  private static final DateTimeFormatter ISO_DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+    .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    .optionalStart().appendOffset("+HH:MM", "+00:00").optionalEnd()
+    .optionalStart().appendOffset("+HHMM", "+0000").optionalEnd()
+    .optionalStart().appendOffset("+HH", "Z").optionalEnd()
+    .toFormatter();
+
+  private ContextDateTimeFormatter() {
+  }
+
+  public static void formatDatesInJson(JsonObject json, String languageTag, String zoneId) {
+    mapValuesInJson(json, getDateMapper(languageTag, zoneId), String.class);
+  }
+
+  private static <T> void mapValuesInJson(JsonObject json, Function<T, ?> mapper, Class<T> classToMap) {
+    for (Map.Entry<String, Object> entry : json) {
+      Object value = entry.getValue();
+      if (value == null) {
+        continue;
+      }
+      if (value.getClass() == JsonObject.class) {
+        mapValuesInJson((JsonObject) entry.getValue(), mapper, classToMap);
+      } else if (value.getClass() == classToMap) {
+        Object mappedValue = mapper.apply(classToMap.cast(value));
+        json.put(entry.getKey(), mappedValue);
+      }
+    }
+  }
+
+  private static Function<String, String> getDateMapper(String languageTag, String zoneId) {
+    return value -> localizeIfStringIsIsoDate(value, zoneId, languageTag);
+  }
+
+  private static String localizeIfStringIsIsoDate(String value, String zoneId, String languageTag) {
+    try {
+      ZonedDateTime parsedDateTime = ZonedDateTime.parse(value, ISO_DATE_TIME_FORMATTER)
+        .withZoneSameInstant(ZoneId.of(zoneId));
+      DateTimeFormatter localizedFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+        .withLocale(Locale.forLanguageTag(languageTag));
+
+      return parsedDateTime.format(localizedFormatter);
+    } catch (DateTimeParseException e) {
+      //value is not date
+      return value;
+    }
+  }
+}

--- a/src/main/java/org/folio/template/util/OkapiConnectionParams.java
+++ b/src/main/java/org/folio/template/util/OkapiConnectionParams.java
@@ -1,0 +1,43 @@
+package org.folio.template.util;
+
+
+import java.util.Map;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+
+/**
+ * Wrapper class for Okapi connection params
+ */
+public class OkapiConnectionParams {
+
+  private static final String OKAPI_HEADER_URL = "x-okapi-url";
+
+  private String okapiUrl;
+  private String tenant;
+  private String token;
+
+  public OkapiConnectionParams(String okapiUrl, String tenant, String token) {
+    this.okapiUrl = okapiUrl;
+    this.tenant = tenant;
+    this.token = token;
+  }
+
+  public OkapiConnectionParams(Map<String, String> okapiHeaders) {
+    this.okapiUrl = okapiHeaders.get(OKAPI_HEADER_URL);
+    this.tenant = okapiHeaders.get(OKAPI_HEADER_TENANT);
+    this.token = okapiHeaders.get(OKAPI_HEADER_TOKEN);
+  }
+
+  public String getOkapiUrl() {
+    return okapiUrl;
+  }
+
+  public String getTenant() {
+    return tenant;
+  }
+
+  public String getToken() {
+    return token;
+  }
+}

--- a/src/main/java/org/folio/template/util/OkapiModuleClientException.java
+++ b/src/main/java/org/folio/template/util/OkapiModuleClientException.java
@@ -1,0 +1,23 @@
+package org.folio.template.util;
+
+/**
+ * Exception indicating that okapi module responded in unexpected way
+ */
+public class OkapiModuleClientException extends RuntimeException {
+
+  public OkapiModuleClientException() {
+    super();
+  }
+
+  public OkapiModuleClientException(String message) {
+    super(message);
+  }
+
+  public OkapiModuleClientException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public OkapiModuleClientException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
+++ b/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
@@ -1,9 +1,12 @@
 package org.folio.rest.impl;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.builder.RequestSpecBuilder;
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.specification.RequestSpecification;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -13,6 +16,8 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.Context;
 import org.folio.rest.jaxrs.model.LocalizedTemplates;
 import org.folio.rest.jaxrs.model.LocalizedTemplatesProperty;
@@ -28,13 +33,27 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.vertx.core.json.JsonObject.mapFrom;
 
 @RunWith(VertxUnitRunner.class)
 public class TemplateRequestTest {
 
-  private static final String TENANT = "diku";
+  private static final String OKAPI_HEADER_URL = "x-okapi-url";
+
+  private static final String TENANT = "testtenant";
+  private static final String DUMMY_TOKEN = "dummy-token";
+  private static final String LOCALHOST = "http://localhost";
+
   private static final String TEMPLATE_PATH = "/templates";
   private static final String TEMPLATE_REQUEST_PATH = "/template-request";
+  private static final String CONFIG_REQUEST_PATH = "/configurations/entries";
+
 
   private static final String TEMPLATES_TABLE_NAME = "template";
 
@@ -42,14 +61,22 @@ public class TemplateRequestTest {
   public static final String EN_LANG = "en";
 
   private static Vertx vertx;
-  private static int port;
-  private static RequestSpecification spec;
+  private static String moduleUrl;
+
+  @org.junit.Rule
+  public WireMockRule mockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new ConsoleNotifier(true)));
+
+  private RequestSpecification spec;
 
   @BeforeClass
   public static void setUpClass(final TestContext context) throws Exception {
     Async async = context.async();
     vertx = Vertx.vertx();
-    port = NetworkUtils.nextFreePort();
+    int port = NetworkUtils.nextFreePort();
+    moduleUrl = LOCALHOST + ':' + port;
 
     String useExternalDatabase = System.getProperty(
       "org.folio.password.validator.test.database",
@@ -76,7 +103,7 @@ public class TemplateRequestTest {
         throw new Exception(message);
     }
 
-    TenantClient tenantClient = new TenantClient("localhost", port, "diku", "dummy-token");
+    TenantClient tenantClient = new TenantClient(LOCALHOST + ':' + port, TENANT, DUMMY_TOKEN);
     DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, res -> {
       try {
@@ -87,16 +114,18 @@ public class TemplateRequestTest {
         e.printStackTrace();
       }
     });
-
-    spec = new RequestSpecBuilder()
-      .setContentType(ContentType.JSON)
-      .setBaseUri("http://localhost:" + port)
-      .addHeader(RestVerticle.OKAPI_HEADER_TENANT, TENANT)
-      .build();
   }
 
   @Before
   public void setUp(TestContext context) {
+    spec = new RequestSpecBuilder()
+      .setContentType(ContentType.JSON)
+      .setBaseUri(moduleUrl)
+      .addHeader(RestVerticle.OKAPI_HEADER_TENANT, TENANT)
+      .addHeader(RestVerticle.OKAPI_HEADER_TOKEN, DUMMY_TOKEN)
+      .addHeader(OKAPI_HEADER_URL, LOCALHOST + ':' + mockServer.port())
+      .build();
+    mockConfigModule();
     clearTemplatesTable(context);
   }
 
@@ -240,6 +269,104 @@ public class TemplateRequestTest {
       .body("meta.outputFormat", Matchers.is(TXT_OUTPUT_FORMAT));
   }
 
+  @Test
+  public void shouldLocalizeDatesAccordingToDefaultConfiguration() {
+    Template template = new Template()
+      .withDescription("Template with dates")
+      .withOutputFormats(Arrays.asList(TXT_OUTPUT_FORMAT, "html"))
+      .withTemplateResolver("mustache")
+      .withLocalizedTemplates(
+        new LocalizedTemplates()
+          .withAdditionalProperty(EN_LANG,
+            new LocalizedTemplatesProperty()
+              .withHeader("Request created on {{request.creationDate}}")
+              .withBody("Due date is {{loan.dueDate}}")));
+
+    String templateId = postTemplate(template);
+
+    String requestDate = "2019-06-10T18:32:31.000+0100";
+    String loanDueDate = "2019-06-18T14:04:33.205Z";
+
+    TemplateProcessingRequest templateRequest =
+      new TemplateProcessingRequest()
+        .withTemplateId(templateId)
+        .withLang(EN_LANG)
+        .withOutputFormat(TXT_OUTPUT_FORMAT)
+        .withContext(new Context()
+          .withAdditionalProperty("request",
+            new JsonObject()
+              .put("creationDate", requestDate))
+          .withAdditionalProperty("loan",
+            new JsonObject()
+              .put("dueDate", loanDueDate)));
+
+    String expectedHeader = "Request created on 6/10/19 5:32 PM";
+    String expectedBody = "Due date is 6/18/19 2:04 PM";
+
+    RestAssured.given()
+      .spec(spec)
+      .body(toJson(templateRequest))
+      .when()
+      .post(TEMPLATE_REQUEST_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("templateId", Matchers.is(templateId))
+      .body("result.header", Matchers.is(expectedHeader))
+      .body("result.body", Matchers.is(expectedBody))
+      .body("meta.lang", Matchers.is(EN_LANG))
+      .body("meta.outputFormat", Matchers.is(TXT_OUTPUT_FORMAT));
+  }
+
+  @Test
+  public void shouldLocalizeDatesAccordingToConfigurationSetup() {
+    Template template = new Template()
+      .withDescription("Template with dates")
+      .withOutputFormats(Arrays.asList(TXT_OUTPUT_FORMAT, "html"))
+      .withTemplateResolver("mustache")
+      .withLocalizedTemplates(
+        new LocalizedTemplates()
+          .withAdditionalProperty(EN_LANG,
+            new LocalizedTemplatesProperty()
+              .withHeader("Request created on {{request.creationDate}}")
+              .withBody("Due date is {{loan.dueDate}}")));
+
+    String templateId = postTemplate(template);
+
+    String requestDate = "2019-06-10T18:32:31.000+0100";
+    String loanDueDate = "2019-06-18T14:04:33.205Z";
+
+    TemplateProcessingRequest templateRequest =
+      new TemplateProcessingRequest()
+        .withTemplateId(templateId)
+        .withLang(EN_LANG)
+        .withOutputFormat(TXT_OUTPUT_FORMAT)
+        .withContext(new Context()
+          .withAdditionalProperty("request",
+            new JsonObject()
+              .put("creationDate", requestDate))
+          .withAdditionalProperty("loan",
+            new JsonObject()
+              .put("dueDate", loanDueDate)));
+
+    mockLocaleSettings("de-DE", "Europe/Berlin");
+
+    String expectedHeader = "Request created on 10.06.19 19:32";
+    String expectedBody = "Due date is 18.06.19 16:04";
+
+    RestAssured.given()
+      .spec(spec)
+      .body(toJson(templateRequest))
+      .when()
+      .post(TEMPLATE_REQUEST_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("templateId", Matchers.is(templateId))
+      .body("result.header", Matchers.is(expectedHeader))
+      .body("result.body", Matchers.is(expectedBody))
+      .body("meta.lang", Matchers.is(EN_LANG))
+      .body("meta.outputFormat", Matchers.is(TXT_OUTPUT_FORMAT));
+  }
+
   private String postTemplate(Template template) {
     return RestAssured.given()
       .spec(spec)
@@ -253,7 +380,7 @@ public class TemplateRequestTest {
   }
 
   private String toJson(Object object) {
-    return JsonObject.mapFrom(object).toString();
+    return mapFrom(object).toString();
   }
 
   private Template createTemplate() {
@@ -271,5 +398,25 @@ public class TemplateRequestTest {
             new LocalizedTemplatesProperty()
               .withHeader("Hallo message for {{user.name}}")
               .withBody("Hallo {{user.name}}")));
+  }
+
+  private void mockConfigModule() {
+    Configurations configurations =
+      new Configurations().withConfigs(Collections.emptyList()).withTotalRecords(0);
+    stubFor(get(urlPathEqualTo(CONFIG_REQUEST_PATH))
+      .willReturn(okJson(toJson(mapFrom(configurations)))));
+  }
+
+  private void mockLocaleSettings(String languageToken, String timezoneId) {
+    String localeConfigValue = new JsonObject()
+      .put("locale", languageToken)
+      .put("timezone", timezoneId).encode();
+
+    Config config = new Config().withValue(localeConfigValue);
+    Configurations configurations =
+      new Configurations().withConfigs(Collections.singletonList(config)).withTotalRecords(1);
+
+    stubFor(get(urlPathEqualTo(CONFIG_REQUEST_PATH))
+      .willReturn(okJson(toJson(configurations))));
   }
 }

--- a/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
+++ b/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
@@ -46,7 +46,7 @@ public class TemplateRequestTest {
 
   private static final String OKAPI_HEADER_URL = "x-okapi-url";
 
-  private static final String TENANT = "testtenant";
+  private static final String TENANT = "diku";
   private static final String DUMMY_TOKEN = "dummy-token";
   private static final String LOCALHOST = "http://localhost";
 


### PR DESCRIPTION
## Purpose
Resolves: [MODTEMPENG-18](https://issues.folio.org/browse/MODTEMPENG-18)
Localize dates from context at the time of template processing.
## Approach
Tenant-selected language tag and timezone are taken from mod-configuration.
Every string from template context that matches ISO 8601 date format is localized.