### PR TITLE
[MODTEMPENG-25] Fix date-time internationalization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
       <version>${raml-module-builder.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>64.2</version>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
       <version>${vertx-version}</version>
@@ -142,6 +147,12 @@
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <version>5.5.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.4.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
+++ b/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
@@ -1,8 +1,37 @@
 package org.folio.rest.impl;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.vertx.core.json.JsonObject.mapFrom;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configurations;
+import org.folio.rest.jaxrs.model.Context;
+import org.folio.rest.jaxrs.model.LocalizedTemplates;
+import org.folio.rest.jaxrs.model.LocalizedTemplatesProperty;
+import org.folio.rest.jaxrs.model.Template;
+import org.folio.rest.jaxrs.model.TemplateProcessingRequest;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -14,24 +43,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.http.HttpStatus;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.client.TenantClient;
-import org.folio.rest.jaxrs.model.*;
-import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.utils.NetworkUtils;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static io.vertx.core.json.JsonObject.mapFrom;
 
 @RunWith(VertxUnitRunner.class)
 public class TemplateRequestTest {
@@ -292,8 +303,8 @@ public class TemplateRequestTest {
             new JsonObject()
               .put("dueDate", loanDueDate)));
 
-    String expectedHeader = "Request created on 6/10/19 5:32 PM";
-    String expectedBody = "Due date is 6/18/19 2:04 PM";
+    String expectedHeader = "Request created on 6/10/19, 5:32 PM";
+    String expectedBody = "Due date is 6/18/19, 2:04 PM";
 
     RestAssured.given()
       .spec(spec)
@@ -342,8 +353,8 @@ public class TemplateRequestTest {
 
     mockLocaleSettings("de-DE", "Europe/Berlin");
 
-    String expectedHeader = "Request created on 10.06.19 19:32";
-    String expectedBody = "Due date is 18.06.19 16:04";
+    String expectedHeader = "Request created on 10.06.19, 19:32";
+    String expectedBody = "Due date is 18.06.19, 16:04";
 
     RestAssured.given()
       .spec(spec)
@@ -431,7 +442,7 @@ public class TemplateRequestTest {
 
     mockLocaleSettings("de-DE", "Europe/Berlin");
 
-    String expectedBody = "Dates are: 10.06.19 19:32; 18.06.19 16:04;";
+    String expectedBody = "Dates are: 10.06.19, 19:32; 18.06.19, 16:04;";
 
     RestAssured.given()
       .spec(spec)

--- a/src/test/java/org/folio/template/util/ContextDateTimeFormatterTest.java
+++ b/src/test/java/org/folio/template/util/ContextDateTimeFormatterTest.java
@@ -54,7 +54,6 @@ class ContextDateTimeFormatterTest {
     assertEquals(expectedJson, inputJson);
   }
 
-
   @ParameterizedTest
   @CsvSource(value = {
     "Asia/Hong_Kong | zh-CN | 2019/9/18 下午10:04",

--- a/src/test/java/org/folio/template/util/ContextDateTimeFormatterTest.java
+++ b/src/test/java/org/folio/template/util/ContextDateTimeFormatterTest.java
@@ -1,10 +1,19 @@
 package org.folio.template.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.Locale;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.ibm.icu.util.TimeZone;
+
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.Assert.assertEquals;
 
 class ContextDateTimeFormatterTest {
 
@@ -14,7 +23,7 @@ class ContextDateTimeFormatterTest {
   @Test
   void allTheDatesAreLocalizedInJsonObject() {
     String inputIsoDate = "2019-06-18T14:04:33.205Z";
-    String expectedFormattedDate = "6/18/19 2:04 PM";
+    String expectedFormattedDate = "6/18/19, 2:04 PM";
 
     JsonObject inputJson = new JsonObject()
       .put("dateInRoot", inputIsoDate)
@@ -43,5 +52,22 @@ class ContextDateTimeFormatterTest {
     ContextDateTimeFormatter.formatDatesInJson(inputJson, LANGUAGE_TAG, TIMEZONE_ID);
 
     assertEquals(expectedJson, inputJson);
+  }
+
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "Asia/Hong_Kong | zh-CN | 2019/9/18 下午10:04",
+    "Europe/Copenhagen | da-DK | 18.09.2019 16.04",
+    "Europe/London | en-GB | 18/09/2019, 15:04",
+    "Europe/Stockholm | en-SE | 2019-09-18, 16:04",
+    "America/New_York | en-US | 9/18/19, 10:04 AM",
+  }, delimiter = '|')
+  void shouldFormatDateDependingOnLocaleAndTimeZone(String timeZoneId, String langTag, String expected) {
+    String inputIsoDate = "2019-09-18T14:04:33.205Z";
+    String formattedDate = ContextDateTimeFormatter.localizeIfStringIsIsoDate(inputIsoDate,
+      TimeZone.getTimeZone(timeZoneId), Locale.forLanguageTag(langTag));
+
+    assertThat(formattedDate, Matchers.is(expected));
   }
 }


### PR DESCRIPTION
## Purpose 
Fix date-time internationalization
Resolves: [MODTEMPENG-25](https://issues.folio.org/browse/MODTEMPENG-25)

## Approach
- Use [ICU4J](https://wiki.eclipse.org/ICU4J) library for dates formatting