### PR TITLE
MODTEMPENG-27 Reset password email: Entire Reset password URL is not hyperlinked | Revised reset password template

### DIFF
--- a/src/main/resources/templates/db_scripts/populate-templates.sql
+++ b/src/main/resources/templates/db_scripts/populate-templates.sql
@@ -31,13 +31,13 @@ INSERT INTO template (_id, jsonb) VALUES
  "id": "ed8c1c67-897b-4a23-a702-c36e280c6a93",
  "description": "Rest password email",
  "outputFormats": [
-   "text/plain"
+   "text/html"
  ],
  "templateResolver": "mustache",
  "localizedTemplates": {
    "en": {
      "header": "Reset your Folio account",
-     "body": "{{user.personal.firstName}}\n\nYour Folio password has been reset. Please use this link to reset your password: {{link}}\n\nIf you do not reset your password within 24 hours of the delivery of this email, then contact your Folio Administrator to reset your password.\n\nRegards,\n\n{{institution.name}} Folio Administration"
+     "body": "<p>{{user.personal.firstName}}</p><p>Your request to reset your password has been received.</p> <p>To reset your password, please <a href={{link}}>[*visit this link*]</a>.</p><p>NOTE: If you do not reset your password within {{expirationNumber}}{{^expirationNumber}}24{{/expirationNumber}} {{expirationUnitOfTime}}{{^expirationUnitOfTime}}hours{{/expirationUnitOfTime}} of the delivery of this email, the link will no longer operate. Please contact your FOLIO system administrator if you are unable to reset your password.</p><p>Regards,</p><p>{{institution.name}} FOLIO Administration</p>"
    }
  }
 }'),

--- a/src/main/resources/templates/db_scripts/populate-templates.sql
+++ b/src/main/resources/templates/db_scripts/populate-templates.sql
@@ -37,7 +37,7 @@ INSERT INTO template (_id, jsonb) VALUES
  "localizedTemplates": {
    "en": {
      "header": "Reset your Folio account",
-     "body": "<p>{{user.personal.firstName}}</p><p>Your request to reset your password has been received.</p> <p>To reset your password, please <a href={{link}}>[*visit this link*]</a>.</p><p>NOTE: If you do not reset your password within {{expirationNumber}}{{^expirationNumber}}24{{/expirationNumber}} {{expirationUnitOfTime}}{{^expirationUnitOfTime}}hours{{/expirationUnitOfTime}} of the delivery of this email, the link will no longer operate. Please contact your FOLIO system administrator if you are unable to reset your password.</p><p>Regards,</p><p>{{institution.name}} FOLIO Administration</p>"
+     "body": "<p>{{user.personal.firstName}}</p><p>Your request to reset your password has been received.</p> <p>To reset your password, please <a href={{link}}>visit this link</a>.</p><p>NOTE: If you do not reset your password within {{expirationNumber}}{{^expirationNumber}}24{{/expirationNumber}} {{expirationUnitOfTime}}{{^expirationUnitOfTime}}hours{{/expirationUnitOfTime}} of the delivery of this email, the link will no longer operate. Please contact your FOLIO system administrator if you are unable to reset your password.</p><p>Regards,</p><p>{{institution.name}} FOLIO Administration</p>"
    }
  }
 }'),


### PR DESCRIPTION
**Purpose**
Updating reset password email template

Resolve:[MODTEMPENG-27](https://issues.folio.org/browse/MODTEMPENG-27)
