### PR TITLE
[MODTEMPENG-30] mod-template-engine does not purge tenant data

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -60,9 +60,10 @@
       "interfaceType": "system",
       "handlers": [
         {
-          "methods": [
-            "POST"
-          ],
+          "methods": ["POST"],
+          "pathPattern": "/_/tenant"
+        }, {
+          "methods": ["DELETE"],
           "pathPattern": "/_/tenant"
         }
       ]

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <postgres.driver.version>9.4.1212</postgres.driver.version>
     <vertx-version>3.5.4</vertx-version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.10</jackson.version>
   </properties>
 
 
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.2</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
- delete method was added to ModuleDescriptor, _tenant interface
- com.fasterxml.jackson.core:jackson-databind was updated to version 2.9.10