### PR TITLE
MODTEMPENG-37: Rename column _id to id when upgrading from < 1.7.0

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -5,5 +5,12 @@
       "withMetadata": true,
       "customSnippetPath": "populate-templates.sql"
     }
+  ],
+  "scripts": [
+    {
+      "run": "before",
+      "snippet": "DO $$ BEGIN ALTER TABLE template RENAME COLUMN _id TO id; EXCEPTION WHEN OTHERS THEN END; $$;",
+      "fromModuleVersion": "1.7.0"
+    }
   ]
 }

--- a/src/test/java/org/folio/rest/impl/ApiTestHelper.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestHelper.java
@@ -65,7 +65,7 @@ public class ApiTestHelper {
     HttpClient client = vertx.createHttpClient();
     HttpClientRequest request = client.requestAbs(method, url);
     //Add standard headers
-    request.putHeader("X-Okapi-Tenant", "diku")
+    request.putHeader("X-Okapi-Tenant", Postgres.getTenant())
       .putHeader("content-type", "application/json")
       .putHeader("accept", method.equals(HttpMethod.DELETE) ? "text/plain" : "application/json");
     if (headers != null) {

--- a/src/test/java/org/folio/rest/impl/Postgres.java
+++ b/src/test/java/org/folio/rest/impl/Postgres.java
@@ -1,0 +1,54 @@
+package org.folio.rest.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.UpdateResult;
+
+/**
+ * Start embedded postgres before all test classes and stop it after all test classes.
+ */
+public final class Postgres {
+  private static boolean shutdownHookInstalled = false;
+
+  public static String getTenant() {
+    return "testtenant";
+  }
+
+  public static void init() {
+    // PostgresClient automatically starts embedded postgres if needed
+
+    if (shutdownHookInstalled) {
+      return;
+    }
+    Runtime.getRuntime().addShutdownHook(new Thread(PostgresClient::stopEmbeddedPostgres));
+    shutdownHookInstalled = true;
+  }
+
+  /**
+   * Truncate the template table
+   */
+  public static void truncate() {
+    CompletableFuture<UpdateResult> future = new CompletableFuture<>();
+
+    PostgresClient.getInstance(Vertx.vertx()).execute(
+        "TRUNCATE " + getTenant() + "_mod_template_engine.template CASCADE", handler -> {
+      if (handler.failed()) {
+        future.completeExceptionally(handler.cause());
+        return;
+      }
+      future.complete(handler.result());
+    });
+
+    try {
+      future.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/org/folio/rest/impl/RestVerticleTest.java
+++ b/src/test/java/org/folio/rest/impl/RestVerticleTest.java
@@ -17,6 +17,10 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.TenantAttributes;
@@ -83,22 +87,25 @@ public class RestVerticleTest {
     vertx = Vertx.vertx();
 
     Postgres.init();
+    Postgres.dropSchema();
 
     DeploymentOptions options = new DeploymentOptions().setConfig(
       new JsonObject()
         .put("http.port", okapiPort)
     );
 
-    vertx.deployVerticle(RestVerticle.class.getName(), options, res -> {
+    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess(res -> {
       try {
         TenantAttributes t = new TenantAttributes().withModuleTo("mod-template-engine-1.0.0");
         tenantClient.postTenant(t, res2 -> {
+          assertThat(res2.statusCode(), is(201));
+          System.out.println("X");
           async.complete();
         });
       } catch (Exception e) {
         context.fail(e);
       }
-    });
+    }));
   }
 
   @Before


### PR DESCRIPTION
This is due to the change in RMB version 25: https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-25