### PR TITLE
MODTEMPENG-44 update account activation email template

### DIFF
--- a/src/main/resources/templates/db_scripts/populate-templates.sql
+++ b/src/main/resources/templates/db_scripts/populate-templates.sql
@@ -22,7 +22,7 @@ INSERT INTO template (id, jsonb) VALUES
  "templateResolver": "mustache",
  "localizedTemplates": {
    "en": {
-     "header": "Activate your Folio account",
+     "header": "Complete activation of your FOLIO account",
      "body": "<p>{{user.personal.firstName}}</p><p>Your FOLIO account has been activated.</p><p>Your username is {{user.username}}.</p><p>To complete activation of your account, please use the following link to create a password for your FOLIO account: <a href={{link}}>visit this link</a></p><p>If you do not create a password within 24 hours of the delivery of this email, then contact your FOLIO Administrator to receive a new create password link.</p><p>Regards,</p><p>{{institution.name}} FOLIO Administration</p>"
    }
  }


### PR DESCRIPTION
## Purpose
Update create password email template so that create password page link does not display but replaced with the link text - 'visit this link' which is hyperlinked to the create password page.
Update subject line of Account activation email template.

Resolves: [MODTEMPENG-44](https://issues.folio.org/browse/MODTEMPENG-44)

## Approach 
Update populate-templates.sql script that saves templates to DB