### PR TITLE
MODTEMPENG-48 update RMB and vetx versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>29.0.1</raml-module-builder.version>
+    <raml-module-builder.version>30.0.2</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx-version>3.8.1</vertx-version>
+    <vertx-version>3.9.1</vertx-version>
   </properties>
 
   <repositories>

--- a/src/main/java/org/folio/rest/impl/TemplateRequestImpl.java
+++ b/src/main/java/org/folio/rest/impl/TemplateRequestImpl.java
@@ -28,7 +28,7 @@ public class TemplateRequestImpl implements TemplateRequest {
           .map(PostTemplateRequestResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)
-          .setHandler(asyncResultHandler);
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         asyncResultHandler.handle(Future.succeededFuture(
           TemplateEngineHelper.mapExceptionToResponse(e)));

--- a/src/main/java/org/folio/rest/impl/TemplateResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/TemplateResourceImpl.java
@@ -31,7 +31,7 @@ public class TemplateResourceImpl implements Templates {
         templateService.addTemplate(entity)
           .map((Response) PostTemplatesResponse.respond201WithApplicationJson(entity))
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)
-          .setHandler(asyncResultHandler);
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         asyncResultHandler.handle(Future.succeededFuture(
           TemplateEngineHelper.mapExceptionToResponse(e)));
@@ -54,7 +54,7 @@ public class TemplateResourceImpl implements Templates {
           ).map(GetTemplatesResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)
-          .setHandler(asyncResultHandler);
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         asyncResultHandler.handle(Future.succeededFuture(
           TemplateEngineHelper.mapExceptionToResponse(e)));
@@ -74,7 +74,7 @@ public class TemplateResourceImpl implements Templates {
           .map(GetTemplatesByTemplateIdResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)
-          .setHandler(asyncResultHandler);
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         asyncResultHandler.handle(Future.succeededFuture(
           TemplateEngineHelper.mapExceptionToResponse(e)));
@@ -97,7 +97,7 @@ public class TemplateResourceImpl implements Templates {
             buildTemplateNotFound(templateId)
           )
           .otherwise(TemplateEngineHelper::mapExceptionToResponse)
-          .setHandler(asyncResultHandler);
+          .onComplete(asyncResultHandler);
       } catch (Exception e) {
         asyncResultHandler.handle(Future.succeededFuture(
           TemplateEngineHelper.mapExceptionToResponse(e)));
@@ -118,7 +118,7 @@ public class TemplateResourceImpl implements Templates {
         String.format("Template with id: %s deleted", templateId)) :
       buildTemplateNotFound(templateId))
       .otherwise(TemplateEngineHelper::mapExceptionToResponse)
-      .setHandler(asyncResultHandler);
+      .onComplete(asyncResultHandler);
   }
 
   private Response buildTemplateNotFound(String templateId) {

--- a/src/main/java/org/folio/template/dao/TemplateDaoImpl.java
+++ b/src/main/java/org/folio/template/dao/TemplateDaoImpl.java
@@ -1,9 +1,9 @@
 package org.folio.template.dao;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.ext.sql.UpdateResult;
+import java.util.List;
+import java.util.Optional;
+
+import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.jaxrs.model.Template;
 import org.folio.rest.persist.Criteria.Limit;
@@ -11,10 +11,12 @@ import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
-import org.folio.cql2pgjson.CQL2PgJSON;
 
-import java.util.List;
-import java.util.Optional;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 
 public class TemplateDaoImpl implements TemplateDao {
 
@@ -60,16 +62,16 @@ public class TemplateDaoImpl implements TemplateDao {
 
   @Override
   public Future<Boolean> updateTemplate(Template template) {
-    Promise<UpdateResult> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     pgClient.update(TEMPLATES_TABLE, template, template.getId(), promise);
-    return promise.future().map(updateResult -> updateResult.getUpdated() == 1);
+    return promise.future().map(updateResult -> updateResult.rowCount() == 1);
   }
 
   @Override
   public Future<Boolean> deleteTemplate(String id) {
-    Promise<UpdateResult> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     pgClient.delete(TEMPLATES_TABLE, id, promise);
-    return promise.future().map(updateResult -> updateResult.getUpdated() == 1);
+    return promise.future().map(updateResult -> updateResult.rowCount() == 1);
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/Postgres.java
+++ b/src/test/java/org/folio/rest/impl/Postgres.java
@@ -8,7 +8,8 @@ import java.util.concurrent.TimeoutException;
 import org.folio.rest.persist.PostgresClient;
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.sql.UpdateResult;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 
 /**
  * Start embedded postgres before all test classes and stop it after all test classes.
@@ -31,8 +32,8 @@ public final class Postgres {
     shutdownHookInstalled = true;
   }
 
-  public static UpdateResult runSql(String sql) {
-    CompletableFuture<UpdateResult> future = new CompletableFuture<>();
+  public static RowSet<Row> runSql(String sql) {
+    CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
 
     PostgresClient.getInstance(vertx).execute(sql, handler -> {
       if (handler.failed()) {
@@ -52,8 +53,8 @@ public final class Postgres {
   /**
    * Run sql, return null on exception.
    */
-  public static UpdateResult runSqlIgnore(String sql) {
-    CompletableFuture<UpdateResult> future = new CompletableFuture<>();
+  public static RowSet<Row> runSqlIgnore(String sql) {
+    CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
 
     PostgresClient.getInstance(vertx).execute(sql, handler -> {
       if (handler.failed()) {

--- a/src/test/java/org/folio/rest/impl/RestVerticleTest.java
+++ b/src/test/java/org/folio/rest/impl/RestVerticleTest.java
@@ -163,7 +163,7 @@ public class RestVerticleTest {
         context.assertEquals(h.getJson().getInteger("totalRecords"), 0);
       }));
 
-    chainedFuture.setHandler(chainedRes -> {
+    chainedFuture.onComplete(chainedRes -> {
       if (chainedRes.failed()) {
         logger.error("Test failed: " + chainedRes.cause().getLocalizedMessage());
         context.fail(chainedRes.cause());

--- a/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
+++ b/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.UUID;
 
 import org.apache.http.HttpStatus;
 import org.folio.rest.RestVerticle;
@@ -120,7 +121,7 @@ public class TemplateRequestTest {
 
     TemplateProcessingRequest templateRequest =
       new TemplateProcessingRequest()
-        .withTemplateId("not-existing-id")
+        .withTemplateId(UUID.randomUUID().toString())
         .withLang(EN_LANG)
         .withOutputFormat(TXT_OUTPUT_FORMAT);
 
@@ -130,7 +131,7 @@ public class TemplateRequestTest {
       .when()
       .post(TEMPLATE_REQUEST_PATH)
       .then()
-      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+      .statusCode(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test


### PR DESCRIPTION
## Approach
- Update to RMB v30.0.2
- Update vertx to 3.9.1
- Do all related changes according to RMB upgrading notes

Resolves: [MODTEMPENG-48](https://issues.folio.org/browse/MODTEMPENG-48)