### PR TITLE
FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,12 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-template-engine
 
-Copyright (C) 2018-2019 The Open Library Foundation
+Copyright (C) 2018-2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-template-engine section of API documentation will be automatically reconfigured tomorrow:
https://dev.folio.org/reference/api/#explain-gather-config