### PR TITLE
MODTEMPENG-75 Upgrade RMB to v33.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx-version>4.1.0.CR1</vertx-version>
   </properties>


### PR DESCRIPTION
Update Log4j to a newer version with CVE-2021-44228 vulnerability fixed.