### PR TITLE
MODTEMPENG-85: mod-template-engine - Morning Glory 2022 R2 - Vert.x 3.7.1/v4 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,18 +53,15 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
-      <version>${vertx-version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>${vertx-version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <version>${vertx-version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
@@ -95,7 +92,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -136,7 +132,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
-      <version>3.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Purpose
[MODTEMPENG-85](https://issues.folio.org/browse/MODTEMPENG-85)
_mod-template-engine - Morning Glory 2022 R2 - Vert.x 3.7.1/v4 upgrade_