### PR TITLE
MODTEMPENG-87 RMB v34 upgrade - Morning Glory 2022 R2 module release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>33.2.4</raml-module-builder.version>
+    <raml-module-builder.version>34.0.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx-version>4.2.4</vertx-version>
   </properties>


### PR DESCRIPTION
In the scope of the task on module upgrade, proper actions were fulfilled following instructions to upgrade RAML

Upgraded version of RMB to 34.0.0

https://issues.folio.org/browse/MODTEMPENG-87