### PR TITLE
MODTEMPENG-99 Fixing template update issue due to regex

### DIFF
--- a/ramls/templateContent.json
+++ b/ramls/templateContent.json
@@ -6,12 +6,12 @@
   "properties": {
     "header": {
       "type": "string",
-      "pattern": "\\S+.*",
+      "pattern": "(?s)\\S+.*",
       "description": "Template for header"
     },
     "body": {
       "type": "string",
-      "pattern": "\\S+.*",
+      "pattern": "(?s)\\S+.*",
       "description": "Template for body"
     },
     "attachments": {

--- a/ramls/templateContent.json
+++ b/ramls/templateContent.json
@@ -6,7 +6,7 @@
   "properties": {
     "header": {
       "type": "string",
-      "pattern": "(?s)\\S+.*",
+      "pattern": "\\S+.*",
       "description": "Template for header"
     },
     "body": {

--- a/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
+++ b/src/test/java/org/folio/rest/impl/TemplateRequestTest.java
@@ -268,6 +268,35 @@ public class TemplateRequestTest {
   }
 
   @Test
+  public void shouldCreateTemplateWithNewSpaceCharacter() {
+    String body = "Dear {{user.firstName}},\n\nYour password has been changed." +
+      "\nThis is a confirmation that your password was changed on {{dateTime}}.\n\nDid not change " +
+      "your password? Contact your Folio System Administrator to help secure your account." +
+      "\n\t\nRegards,\n\nFolio Support";
+
+    Template template = new Template()
+      .withDescription("Template for password change")
+      .withOutputFormats(Arrays.asList(TXT_OUTPUT_FORMAT))
+      .withTemplateResolver("mustache")
+      .withLocalizedTemplates(
+        new LocalizedTemplates()
+          .withAdditionalProperty(EN_LANG,
+            new LocalizedTemplatesProperty()
+              .withHeader("Hello message for {{user.name}}")
+              .withBody(body)));
+
+    // Tries to create a template with newSpace character
+
+    RestAssured.given()
+      .spec(spec)
+      .body(toJson(template))
+      .when()
+      .post(TEMPLATE_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED);
+  }
+
+  @Test
   public void shouldLocalizeDatesAccordingToDefaultConfiguration() {
     Template template = new Template()
       .withDescription("Template with dates")


### PR DESCRIPTION
## Purpose
The purpose of the PR is to implement https://folio-org.atlassian.net/browse/MODTEMPENG-99

## Approach
The issue is when the body contains \n, no one can able to update the existing templates. The reason is because of . in the existing regex which is not allowing newline characters. So, in order to accept \n, dot all mode is enabled in regex so that it will accept newline characters.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Changes checklist
- [ ] Check logging.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Screenshots
_Let's see those sweet visuals!_
