### PR TITLE
Modtempeng 111 support hrid barcode image

### DIFF
--- a/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
+++ b/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
@@ -85,7 +85,7 @@ public class TemplateContextPreProcessor {
     Set<String> newTokens = new HashSet<>();
 
     contextMap.entrySet().stream()
-      .filter(e -> isSuitableImageSource(e.getKey()))
+      .filter(e -> isBarcodeImageSource(e.getKey()))
       .filter(e -> objectIsNonBlankString(e.getValue()))
       .map(e -> new Token(e.getKey(), (String) e.getValue()))
       .filter(token -> templateTokens.contains(token.shortPath() + SUFFIX_IMAGE))
@@ -104,7 +104,8 @@ public class TemplateContextPreProcessor {
     fixTokensWithHtmlValue(newTokens);
   }
 
-  private boolean isSuitableImageSource(String tokenKey) {
+  /** Will pass tokens with names ending in `.barcode` or `Hrid` */
+  private boolean isBarcodeImageSource(String tokenKey) {
       return tokenKey.endsWith(SUFFIX_BARCODE) || tokenKey.endsWith(SUFFIX_HRID);
   }
 

--- a/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
+++ b/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
@@ -36,6 +36,7 @@ public class TemplateContextPreProcessor {
   private static final String SUFFIX_DATE = "Date";
   private static final String SUFFIX_TIME = "Time";
   private static final String SUFFIX_BARCODE = ".barcode";
+  private static final String SUFFIX_HRID = "Hrid";
   private static final String SUFFIX_IMAGE = "Image";
 
   private final LocalizedTemplatesProperty template;
@@ -62,7 +63,7 @@ public class TemplateContextPreProcessor {
   }
 
   public void process() {
-    LOG.debug("process:: Started processsing");
+    LOG.debug("process:: Started processing");
     enrichContextWithDateTimes();
     formatDatesInContext(context, config.getLanguageTag(), config.getTimeZoneId());
     handleBarcodeImageTokens();
@@ -84,7 +85,7 @@ public class TemplateContextPreProcessor {
     Set<String> newTokens = new HashSet<>();
 
     contextMap.entrySet().stream()
-      .filter(e -> e.getKey().endsWith(SUFFIX_BARCODE))
+      .filter(e -> isSuitableImageSource(e.getKey()))
       .filter(e -> objectIsNonBlankString(e.getValue()))
       .map(e -> new Token(e.getKey(), (String) e.getValue()))
       .filter(token -> templateTokens.contains(token.shortPath() + SUFFIX_IMAGE))
@@ -101,6 +102,10 @@ public class TemplateContextPreProcessor {
     // For HTML to be interpreted correctly by Mustache,
     // tokens must be wrapped in triple curly braces: "{{{...}}}"
     fixTokensWithHtmlValue(newTokens);
+  }
+
+  private boolean isSuitableImageSource(String tokenKey) {
+      return tokenKey.endsWith(SUFFIX_BARCODE) || tokenKey.endsWith(SUFFIX_HRID);
   }
 
   private boolean objectIsNonBlankString(Object obj) {

--- a/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
+++ b/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
@@ -10,13 +10,7 @@ import org.folio.rest.jaxrs.model.LocalizedTemplatesProperty;
 import org.folio.rest.tools.parser.JsonPathParser;
 import org.folio.template.client.LocaleConfiguration;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,8 +29,7 @@ public class TemplateContextPreProcessor {
 
   private static final String SUFFIX_DATE = "Date";
   private static final String SUFFIX_TIME = "Time";
-  private static final String SUFFIX_BARCODE = ".barcode";
-  private static final String SUFFIX_HRID = "Hrid";
+  private static final List<String> BARCODE_IMAGE_SUFFIXES = Arrays.asList(".barcode", "Hrid");
   private static final String SUFFIX_IMAGE = "Image";
 
   private final LocalizedTemplatesProperty template;
@@ -104,9 +97,10 @@ public class TemplateContextPreProcessor {
     fixTokensWithHtmlValue(newTokens);
   }
 
-  /** Will pass tokens with names ending in `.barcode` or `Hrid` */
   private boolean isBarcodeImageSource(String tokenKey) {
-      return tokenKey.endsWith(SUFFIX_BARCODE) || tokenKey.endsWith(SUFFIX_HRID);
+    return BARCODE_IMAGE_SUFFIXES
+      .stream()
+      .anyMatch(tokenKey::endsWith);
   }
 
   private boolean objectIsNonBlankString(Object obj) {


### PR DESCRIPTION
## Purpose
A library needs to add bar code images based on the Instance HRID in notices and slips. Currently the template engine will create images for template tokens named *.barcode only
 
## Approach
Add a single method to extend the filter of bar-code-image capable tokens to include tokens named *`Hrid` besides tokens named *`.barcode`.

## Screenshots
The change has been tested with templates including tokens `item.instanceHrid` and `item.instanceHridImage`: 

![image](https://github.com/user-attachments/assets/052f6b51-3e51-4464-87a3-1598683de7ba)

![image](https://github.com/user-attachments/assets/2dff4cb3-ceb9-4276-9c0e-4cf8717a5a8b)

