### PR TITLE
UIOR-1493 - Add optional scope field to template schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Example of template record:
        "text/html"
      ],
      "templateResolver": "mustache",
+     "scope": "circulation",
      "localizedTemplates": {
        "de": {
          "header": "Hallo message for {{user.name}}",

--- a/ramls/examples/template.sample
+++ b/ramls/examples/template.sample
@@ -6,6 +6,7 @@
     "text/html"
   ],
   "templateResolver": "mustache",
+  "scope": "circulation",
   "localizedTemplates": {
     "en": {
       "header": "Hello message for {{user.name}}",

--- a/ramls/examples/templatesCollection.sample
+++ b/ramls/examples/templatesCollection.sample
@@ -8,6 +8,7 @@
         "text/html"
       ],
       "templateResolver": "mustache",
+      "scope": "circulation",
       "localizedTemplates": {
         "en": {
           "header": "Hello message for {{user.name}}",

--- a/ramls/template.json
+++ b/ramls/template.json
@@ -34,6 +34,10 @@
     "metadata": {
       "type" : "object",
       "$ref" : "raml-util/schemas/metadata.schema"
+    },
+    "scope": {
+      "type": "string",
+      "description": "Context of the template, e.g. 'orders', 'circulation'. Used by each app to filter its own templates."
     }
   },
   "required": [


### PR DESCRIPTION
[UIOR-1493](https://folio-org.atlassian.net/browse/UIOR-1493)  - Add order email template editing to Settings app

  ## Purpose
  Templates in mod-template-engine are shared across multiple FOLIO apps (e.g. orders, circulation), with no built-in way for an app to identify which templates are its own. This change adds an optional `scope` field so each
  app can tag its templates with a context and filter to just those, using the existing `GET /templates?query=` parameter.
  
  ## Approach
  - Add an optional `scope` string property to the `template.json` JSON schema (RMB regenerates the `Template` model from it; stored in the existing JSONB column, so no DB migration is required). Left out of `required` for
  backward compatibility with existing records.
  - Update RAML example payloads `ramls/examples/template.sample` and `templatesCollection.sample` with `"scope": "circulation"` so they remain valid against the updated schema.
  - Add the same `scope` line to the example template record in `README.md`.

